### PR TITLE
[#17] Add `indent` function

### DIFF
--- a/src/Colourista/Pure.hs
+++ b/src/Colourista/Pure.hs
@@ -31,6 +31,7 @@ module Colourista.Pure
       -- * Emphasis
     , bold
     , italic
+    , indent
 
       -- * Reset
     , reset
@@ -207,6 +208,10 @@ italic = fromString $ setSGRCode [SetItalicized True]
 {-# SPECIALIZE italic :: String     #-}
 {-# SPECIALIZE italic :: Text       #-}
 {-# SPECIALIZE italic :: ByteString #-}
+
+-- | Creates an indentation
+indent :: IsString str => Int -> str
+indent amount = fromString $ replicate amount ' '
 
 -- | Code to reset all previous code applied for the terminal output.
 reset :: IsString str => str


### PR DESCRIPTION
I created an `indent` function with the signature shown in the issue.

Shouldn't the function also gets a string which it should indent or is it okay like this?
Should this be used somewhere else?

i.e.:

```
code "some code"
```

And indent this automatically?