### PR TITLE
Update exclusions, because we bumped the tested version but not exclu…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - os: macOS-latest
             ghc: 9.0.2
           - os: macOS-latest
-            ghc: 8.10.4
+            ghc: 8.10.7
           - os: macOS-latest
             ghc: 8.8.4
           - os: macOS-latest
@@ -44,7 +44,7 @@ jobs:
           - os: windows-latest
             ghc: 9.0.2
           - os: windows-latest
-            ghc: 8.10.4
+            ghc: 8.10.7
           - os: windows-latest
             ghc: 8.8.4
           - os: windows-latest


### PR DESCRIPTION
…sions

In particular the build fails on macOS 8.10.7 anyway

<no location info>: error:
    Warning: Couldn't figure out LLVM version!
             Make sure you have installed LLVM between [9 and 13)
ghc: could not execute: opt